### PR TITLE
Permit users to log requests and responses

### DIFF
--- a/ovh/logger.go
+++ b/ovh/logger.go
@@ -1,0 +1,15 @@
+package ovh
+
+import (
+	"net/http"
+)
+
+// Logger is the interface that should be implemented for loggers that wish to
+// log HTTP requests and HTTP responses.
+type Logger interface {
+	// LogRequest logs an HTTP request.
+	LogRequest(*http.Request)
+
+	// LogResponse logs an HTTP response.
+	LogResponse(*http.Response)
+}

--- a/ovh/ovh.go
+++ b/ovh/ovh.go
@@ -65,6 +65,9 @@ type Client struct {
 	// Client is the underlying HTTP client used to run the requests. It may be overloaded but a default one is instanciated in ``NewClient`` by default.
 	Client *http.Client
 
+	// Logger is used to log HTTP requests and responses.
+	Logger Logger
+
 	// Ensures that the timeDelta function is only ran once
 	// sync.Once would consider init done, even in case of error
 	// hence a good old flag
@@ -281,7 +284,17 @@ func (c *Client) NewRequest(method, path string, reqBody interface{}, needAuth b
 
 // Do sends an HTTP request and returns an HTTP response
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
-	return c.Client.Do(req)
+	if c.Logger != nil {
+		c.Logger.LogRequest(req)
+	}
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if c.Logger != nil {
+		c.Logger.LogResponse(resp)
+	}
+	return resp, nil
 }
 
 // CallAPI is the lowest level call helper. If needAuth is true,


### PR DESCRIPTION
This change permits logging of HTTP requests and responses.

This is particularly useful when this library is embedded in an application that wishes to provide a debug log with insights about the HTTP traffic with OVH API endpoints.

The user is free to adopt any logging library he likes as long as he provides a wrapper that implements the `Logger` interface.