### PR TITLE
feat(metrics): API wrapper

### DIFF
--- a/metrics/client-models.go
+++ b/metrics/client-models.go
@@ -1,0 +1,24 @@
+package metrics
+
+import "github.com/ovh/go-ovh/ovh"
+
+type (
+	// ClientService wrap a Metrics service with client methods
+	ClientService struct {
+		*Service
+		ovhClient *ovh.Client
+	}
+
+	// ClientServices is a list of ClientService
+	ClientServices []*ClientService
+
+	// ClientServiceToken wrap a Metrics service token with client methods
+	ClientServiceToken struct {
+		*Token
+		Service   *Service
+		ovhClient *ovh.Client
+	}
+
+	// ClientServiceTokens is a list of ClientServiceToken
+	ClientServiceTokens []*ClientServiceToken
+)

--- a/metrics/client.go
+++ b/metrics/client.go
@@ -1,0 +1,203 @@
+package metrics
+
+import (
+	"github.com/ovh/go-ovh/ovh"
+)
+
+// NewClient for Metrics API based on OVH API one
+func NewClient(ovhClient *ovh.Client) *Client {
+	return &Client{
+		ovhClient: ovhClient,
+	}
+}
+
+// Service related calls
+
+// Services return a service list
+func (c *Client) Services() (ClientServices, error) {
+	serviceNames, err := List(c.ovhClient)
+	if err != nil {
+		return nil, err
+	}
+
+	services := make(ClientServices, len(serviceNames))
+	for i, serviceName := range serviceNames {
+		service, err := Get(c.ovhClient, serviceName)
+		if err != nil {
+			return nil, err
+		}
+		if service == nil {
+			continue
+		}
+
+		services[i] = &ClientService{
+			Service:   service,
+			ovhClient: c.ovhClient,
+		}
+	}
+
+	return services, nil
+}
+
+// Service return a Metrics service
+func (c *Client) Service(serviceName string) (*ClientService, error) {
+	service, err := Get(c.ovhClient, serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClientService{
+		Service:   service,
+		ovhClient: c.ovhClient,
+	}, nil
+}
+
+// Edit Metrics service
+func (cs *ClientService) Edit(er *EditRequest) error {
+	service, err := Edit(cs.ovhClient, cs.Name, er)
+	if err != nil {
+		return err
+	}
+	cs = &ClientService{
+		Service: service,
+	}
+	return nil
+}
+
+// EditContacts Metrics service
+func (cs *ClientService) EditContacts(ec *EditContactRequest) error {
+	return EditContacts(cs.ovhClient, cs.Name, ec)
+}
+
+// Terminate Metrics service
+func (cs *ClientService) Terminate() error {
+	return Terminate(cs.ovhClient, cs.Name)
+}
+
+// ConfirmTermination confirm a Metrics service termination
+func (cs *ClientService) ConfirmTermination(ct *ConfirmTerminationRequest) error {
+	return ConfirmTermination(cs.ovhClient, cs.Name, ct)
+}
+
+// Tokens return a list of tokens for a service
+func (cs *ClientService) Tokens() (ClientServiceTokens, error) {
+	tokenIDs, err := ListTokens(cs.ovhClient, cs.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	tokens := make(ClientServiceTokens, len(tokenIDs))
+	for i, tokenID := range tokenIDs {
+		token, err := GetToken(cs.ovhClient, cs.Name, tokenID)
+		if err != nil {
+			return nil, err
+		}
+		if token == nil {
+			continue
+		}
+
+		tokens[i] = &ClientServiceToken{
+			Token:     token,
+			Service:   cs.Service,
+			ovhClient: cs.ovhClient,
+		}
+	}
+
+	return tokens, nil
+}
+
+// Consumption return the current service consumption
+func (cs *ClientService) Consumption(cr *ConsumptionRequest) (*ConsumptionResponse, error) {
+	return Consumption(cs.ovhClient, cs.Name, cr)
+}
+
+// LookupToken return the mathing tokens
+func (cs *ClientService) LookupToken(ltr *LookupTokenRequest) (ClientServiceTokens, error) {
+	tokenIDs, err := LookupToken(cs.ovhClient, cs.Name, ltr)
+	if err != nil {
+		return nil, err
+	}
+
+	tokens := make(ClientServiceTokens, len(tokenIDs))
+	for i, tokenID := range tokenIDs {
+		token, err := GetToken(cs.ovhClient, cs.Name, tokenID)
+		if err != nil {
+			return nil, err
+		}
+		if token == nil {
+			continue
+		}
+
+		tokens[i] = &ClientServiceToken{
+			Token:     token,
+			Service:   cs.Service,
+			ovhClient: cs.ovhClient,
+		}
+	}
+
+	return tokens, nil
+}
+
+// SetQuota Set overquota limit on Metrics service
+func (cs *ClientService) SetQuota(sqr *SetQuotaRequest) error {
+	if err := SetQuota(cs.ovhClient, cs.Name, sqr); err != nil {
+		return err
+	}
+	cs.Quota.MADS = sqr.MADS
+	return nil
+}
+
+// Infos return the current service billing infos
+func (cs *ClientService) Infos() (*InfosResponse, error) {
+	return Infos(cs.ovhClient, cs.Name)
+}
+
+// EditInfos update Metrics service billing infos
+func (cs *ClientService) EditInfos(eir *EditInfosRequest) error {
+	return EditInfos(cs.ovhClient, cs.Name, eir)
+}
+
+// NewToken update Metrics service billing infos
+func (cs *ClientService) NewToken(ntr *NewTokenRequest) (*ClientServiceToken, error) {
+	token, err := NewToken(cs.ovhClient, cs.Name, ntr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClientServiceToken{
+		Token:     token,
+		Service:   cs.Service,
+		ovhClient: cs.ovhClient,
+	}, nil
+}
+
+// Token return the token on Metrics service with the provided token ID
+func (cs *ClientService) Token(tokenID string) (*ClientServiceToken, error) {
+	token, err := GetToken(cs.ovhClient, cs.Name, tokenID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClientServiceToken{
+		Token:     token,
+		ovhClient: cs.ovhClient,
+	}, nil
+}
+
+// Tokens related calls
+
+// Edit upddate token options
+func (ct *ClientServiceToken) Edit(etr *EditTokenRequest) error {
+	token, err := EditToken(ct.ovhClient, ct.Service.Name, ct.ID, etr)
+	if err != nil {
+		return err
+	}
+
+	ct.Token = token
+	return nil
+}
+
+// Revoke a token
+func (ct *ClientServiceToken) Revoke() error {
+	return RevokeToken(ct.ovhClient, ct.Service.Name, ct.ID)
+}

--- a/metrics/client_test.go
+++ b/metrics/client_test.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/ovh/go-ovh/ovh"
+)
+
+var (
+	ovhClient   *ovh.Client
+	clientIsSet = false
+)
+
+func init() {
+	fmt.Println("Setup ovh client for tests")
+
+	var err error
+	ovhClient, err = ovh.NewEndpointClient("ovh-eu")
+	if err != nil {
+		fmt.Println("Cannot init ovh Client, skip it")
+	} else {
+		clientIsSet = true
+	}
+}
+
+func TestClient_Services(t *testing.T) {
+	type fields struct {
+		ovhClient *ovh.Client
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    ClientServices
+		wantErr bool
+	}{{
+		name: "fetch services",
+		fields: fields{
+			ovhClient: ovhClient,
+		},
+		want: ClientServices{&ClientService{Service: &Service{
+			Name: "cjlgifbfdjbhj",
+		}}},
+		wantErr: false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if ovhClient == nil {
+				return
+			}
+
+			c := &Client{
+				ovhClient: tt.fields.ovhClient,
+			}
+			got, err := c.Services()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Client.Services() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Client.Services() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/metrics/labels-helper.go
+++ b/metrics/labels-helper.go
@@ -1,0 +1,42 @@
+package metrics
+
+// Add a new label
+func (labels TokenLabels) Add(label, value string) TokenLabels {
+	if labels == nil || label == "" || value == "" {
+		return labels
+	}
+
+	return append(labels, TokenLabel{
+		Key:   label,
+		Value: value,
+	})
+}
+
+// Remove existing label
+func (labels TokenLabels) Remove(label string) TokenLabels {
+	if labels == nil || len(labels) == 0 {
+		return labels
+	}
+
+	for i, l := range labels {
+		if l.Key == label {
+			return append(labels[:i], labels[i+1:]...)
+		}
+	}
+	return labels
+}
+
+// Len implement sort.Sort()
+func (labels TokenLabels) Len() int {
+	return len(labels)
+}
+
+// Swap implement sort.Sort()
+func (labels TokenLabels) Swap(i, j int) {
+	labels[i], labels[j] = labels[j], labels[i]
+}
+
+// Less implement sort.Sort()
+func (labels TokenLabels) Less(i, j int) bool {
+	return labels[i].Key < labels[j].Key
+}

--- a/metrics/labels-helper_test.go
+++ b/metrics/labels-helper_test.go
@@ -1,0 +1,67 @@
+package metrics
+
+import (
+	"testing"
+)
+
+func TestTokenLabels_Add(t *testing.T) {
+	type args struct {
+		label string
+		value string
+	}
+	tests := []struct {
+		name       string
+		labels     TokenLabels
+		args       args
+		expect     TokenLabels
+		expectSize int
+	}{{
+		name:   "Normal way",
+		labels: TokenLabels{},
+		args: args{
+			label: "host",
+			value: "A",
+		},
+		expect: TokenLabels{{
+			Key:   "host",
+			Value: "A",
+		}},
+		expectSize: 1,
+	}, {
+		name:   "Empty key does nothing",
+		labels: TokenLabels{},
+		args: args{
+			label: "",
+			value: "A",
+		},
+		expect:     TokenLabels{},
+		expectSize: 0,
+	}, {
+		name:   "Empty value does nothing",
+		labels: TokenLabels{},
+		args: args{
+			label: "host",
+			value: "",
+		},
+		expect:     TokenLabels{},
+		expectSize: 0,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := tt.labels.Add(tt.args.label, tt.args.value)
+
+			if len(labels) != tt.expectSize {
+				t.Errorf("Bad size on TokenLabels{} expect %d, got %d", tt.expectSize, len(labels))
+			}
+
+			for i, tokenLabel := range labels {
+				if tokenLabel.Key != tt.expect[i].Key {
+					t.Errorf("Bad key on TokenLabel expect %s, got %s", tt.expect[i].Key, tokenLabel.Key)
+				}
+				if tokenLabel.Value != tt.expect[i].Value {
+					t.Errorf("Bad value on TokenLabel expect %s, got %s", tt.expect[i].Value, tokenLabel.Value)
+				}
+			}
+		})
+	}
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,137 @@
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/ovh/go-ovh/ovh"
+)
+
+// List all Metrics services IDs
+func List(c *ovh.Client) ([]string, error) {
+	services := []string{}
+	err := c.Get("/metrics", &services)
+	if err != nil {
+		return nil, err
+	}
+	return services, nil
+}
+
+// Get a Metrics service with the given service name
+func Get(c *ovh.Client, serviceName string) (*Service, error) {
+	s := &Service{}
+	err := c.Get(fmt.Sprintf("/metrics/%s", serviceName), s)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Edit Metrics service options
+func Edit(c *ovh.Client, serviceName string, er *EditRequest) (*Service, error) {
+	s := &Service{}
+	err := c.Put(fmt.Sprintf("/metrics/%s", serviceName), er, s)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// EditContacts update Metrics service contacts
+func EditContacts(c *ovh.Client, serviceName string, ecr *EditContactRequest) error {
+	return c.Post(fmt.Sprintf("/metrics/%s/changeContact", serviceName), ecr, nil)
+}
+
+// Terminate a Metrics service
+func Terminate(c *ovh.Client, serviceName string) error {
+	return c.Post(fmt.Sprintf("/metrics/%s/terminate", serviceName), nil, nil)
+}
+
+// ConfirmTermination must be call after service.Terminate() with the termination token (email)
+func ConfirmTermination(c *ovh.Client, serviceName string, ctr *ConfirmTerminationRequest) error {
+	return c.Post(fmt.Sprintf("/metrics/%s/terminate", serviceName), ctr, nil)
+}
+
+// Consumption (MADS & DDP) of the Metrics service
+func Consumption(c *ovh.Client, serviceName string, cr *ConsumptionRequest) (*ConsumptionResponse, error) {
+	cres := &ConsumptionResponse{}
+	err := c.Post(fmt.Sprintf("/metrics/%s/consumption", serviceName), cr, cres)
+	if err != nil {
+		return nil, err
+	}
+	return cres, nil
+}
+
+// LookupToken return mathing tokens resources for a given access token
+func LookupToken(c *ovh.Client, serviceName string, ltr *LookupTokenRequest) ([]string, error) {
+	tokens := []string{}
+	err := c.Post(fmt.Sprintf("/metrics/%s/lookup/token", serviceName), ltr, &tokens)
+	if err != nil {
+		return nil, err
+	}
+	return tokens, nil
+}
+
+// SetQuota on a pay as you go Metrics service
+func SetQuota(c *ovh.Client, serviceName string, sqr *SetQuotaRequest) error {
+	return c.Put(fmt.Sprintf("/metrics/%s/quota", serviceName), sqr, nil)
+}
+
+// Infos return billing informations about Metrics service
+func Infos(c *ovh.Client, serviceName string) (*InfosResponse, error) {
+	ir := &InfosResponse{}
+	err := c.Get(fmt.Sprintf("/metrics/%s/serviceInfos", serviceName), ir)
+	if err != nil {
+		return nil, err
+	}
+	return ir, nil
+}
+
+// EditInfos about Metrics service
+func EditInfos(c *ovh.Client, serviceName string, eir *EditInfosRequest) error {
+	return c.Put(fmt.Sprintf("/metrics/%s/serviceInfos", serviceName), eir, nil)
+}
+
+// ListTokens return a list of tokens ID attached to a Metrics service
+func ListTokens(c *ovh.Client, serviceName string) ([]string, error) {
+	tokens := []string{}
+	err := c.Get(fmt.Sprintf("/metrics/%s/token", serviceName), &tokens)
+	if err != nil {
+		return nil, err
+	}
+	return tokens, nil
+}
+
+// NewToken create a new token with the provided informations
+func NewToken(c *ovh.Client, serviceName string, ntr *NewTokenRequest) (*Token, error) {
+	token := &Token{}
+	err := c.Post(fmt.Sprintf("/metrics/%s/token", serviceName), ntr, token)
+	if err != nil {
+		return nil, err
+	}
+	return token, nil
+}
+
+// GetToken return a Metrics service token
+func GetToken(c *ovh.Client, serviceName, tokenID string) (*Token, error) {
+	token := &Token{}
+	err := c.Get(fmt.Sprintf("/metrics/%s/token/%s", serviceName, tokenID), token)
+	if err != nil {
+		return nil, err
+	}
+	return token, nil
+}
+
+// EditToken update token options
+func EditToken(c *ovh.Client, serviceName, tokenID string, etr *EditTokenRequest) (*Token, error) {
+	token := &Token{}
+	err := c.Put(fmt.Sprintf("/metrics/%s/token/%s", serviceName, tokenID), etr, token)
+	if err != nil {
+		return nil, err
+	}
+	return token, nil
+}
+
+// RevokeToken revoke a token
+func RevokeToken(c *ovh.Client, serviceName, tokenID string) error {
+	return c.Delete(fmt.Sprintf("/metrics/%s/token/%s", serviceName, tokenID), nil)
+}

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -1,0 +1,55 @@
+package metrics
+
+import "time"
+
+type (
+
+	// API Objects
+
+	// Service is Metrics service
+	Service struct {
+		Name          string `json:"name,omitempty"`
+		Description   string `json:"description,omitempty"`
+		Type          string `json:"type,omitempty"`
+		Region        Region `json:"region,omitempty"`
+		Offer         string `json:"offer,omitempty"`
+		Quota         Quota  `json:"quota,omitempty"`
+		Status        string `json:"status,omitempty"`
+		ShouldUpgrade bool   `json:"shouldUpgrade,omitempty"`
+	}
+
+	// Services is list of service
+	Services []*Service
+
+	// Quota of a Metrics service
+	Quota struct {
+		ReferenceMADS    int        `json:"ref_mads,omitempty"`
+		ReferenceDDP     int        `json:"ref_ddp,omitempty"`
+		Retention        int        `json:"retention,omitempty"`
+		MADS             int        `json:"mads,omitempty"`
+		DDP              int        `json:"ddp,omitempty"`
+		Boosted          bool       `json:"boosted,omitempty"`
+		LastModification *time.Time `json:"lastModification,omitempty"`
+	}
+
+	// Region of a Metrics service
+	Region struct {
+		Name        string `json:"name,omitempty"`
+		Description string `json:"description,omitempty"`
+	}
+
+	// Token is a Metrics service token
+	Token struct {
+		ID          string      `json:"id,omitempty"`
+		Access      string      `json:"access,omitempty"`
+		Permission  string      `json:"permission,omitempty"`
+		Description string      `json:"description,omitempty"`
+		Labels      TokenLabels `json:"labels,omitempty"`
+		IsRevoked   bool        `json:"isRevoked,omitempty"`
+		CreatedAt   *time.Time  `json:"createdAt,omitempty"`
+		ExpireAt    *time.Time  `json:"ExpireAt,omitempty"`
+	}
+
+	// Tokens is a list of token
+	Tokens []*Token
+)

--- a/metrics/overview.go
+++ b/metrics/overview.go
@@ -1,0 +1,76 @@
+/*
+Package metrics provides easy to use methods over /metrics OVH API.
+
+This package expose two ways to use OVH Metrics API.
+
+The first one with raw functions calls, the second with a more "struct and methods style".
+
+Raw usage
+
+List Metrics services:
+	client, err := ovh.NewEndpointClient("ovh-eu")
+	if err != nil {
+		fmt.Printf("Error: %q\n", err)
+		return
+	}
+
+	services, err := List(client)
+	fmt.Printf("Metrics services: %+v", services)
+
+	// Output:
+	// ["xmvoqfviqqmf", "baliuvlqbvih", "uvqsdbviuqgh"]
+	//
+
+Get a token:
+	client, err := ovh.NewEndpointClient("ovh-eu")
+	if err != nil {
+		fmt.Printf("Error: %q\n", err)
+		return
+	}
+
+	token, err := GetToken(client, "xmvoqfviqqmf", "cfa8f6e7-77a4-48fb-b446-cdf82749ac04")
+	if err != nil {
+		fmt.Printf("Error: %q\n", err)
+		return
+	}
+
+	fmt.Printf("Token: %+v", token)
+
+	// Output:
+	// {ID: Access: Permission: Description: Labels: IsRevoked: CreatedAt: ExpireAt}
+	//
+
+Metric client usage
+
+List Metrics services:
+	client, err := ovh.NewEndpointClient("ovh-eu")
+	if err != nil {
+		fmt.Printf("Error: %q\n", err)
+		return
+	}
+
+	metricsClient : metrics.NewClient(client)
+
+	services := metricsClient.Services()
+	fmt.Printf("Services: %+v", services)
+
+	// Output:
+	//
+	//
+
+Get a token:
+	service, err := metricsClient.Service("xmvoqfviqqmf")
+	if err != nil {
+		fmt.Printf("Error: %q\n", err)
+		return
+	}
+
+	token, err := service.Token("cfa8f6e7-77a4-48fb-b446-cdf82749ac04")
+	if err != nil {
+		fmt.Printf("Error: %q\n", err)
+		return
+	}
+
+	fmt.Printf("Token: %+v", token)
+*/
+package metrics

--- a/metrics/payloads.go
+++ b/metrics/payloads.go
@@ -1,0 +1,111 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/ovh/go-ovh/ovh"
+)
+
+type (
+	// Client for Metrics API
+	Client struct {
+		ovhClient *ovh.Client
+	}
+
+	// API Request payloads
+
+	// EditRequest edit service
+	EditRequest struct {
+		Description string `json:"description"`
+	}
+
+	// EditContactRequest edit contacts
+	EditContactRequest struct {
+		Admin   string `json:"contactAdmin,omitempty"`
+		Tech    string `json:"contactTech,omitempty"`
+		Billing string `json:"contactBilling,omitempty"`
+	}
+
+	// ConfirmTerminationRequest confirm termination
+	ConfirmTerminationRequest struct {
+		Commentary string `json:"commentary,omitempty"`
+		FuturUse   string `json:"futureUse,omitempty"`
+		Reason     string `json:"reason,omitempty"`
+		Token      string `json:"token,omitempty"`
+	}
+
+	// ConsumptionRequest service consumption
+	ConsumptionRequest struct {
+		Duration int `json:"duration"`
+	}
+
+	// ConsumptionResponse service consumption
+	ConsumptionResponse struct {
+		MADS int `json:"mads,omitempty"`
+		DDP  int `json:"ddp,omitempty"`
+	}
+
+	// LookupTokenRequest search for token
+	LookupTokenRequest struct {
+		Token string `json:"accessToken"`
+	}
+
+	// SetQuotaRequest set pay as you go quota
+	SetQuotaRequest struct {
+		MADS int `json:"quota"`
+	}
+
+	// InfosResponse billing infos
+	InfosResponse struct {
+		ServiceID             int64        `json:"serviceId,omitempty"`
+		Domain                string       `json:"domain,omitempty"`
+		Status                string       `json:"status,omitempty"`
+		Renew                 ServiceRenew `json:"renew,omitempty"`
+		RenewalType           string       `json:"renewalType,omitempty"`
+		PossibleRenewPeriod   []int64      `json:"possibleRenewPeriod,omitempty"`
+		EngagedUpTo           *time.Time   `json:"engagedUpTo,omitempty"`
+		Creation              *time.Time   `json:"creation,omitempty"`
+		Expiration            *time.Time   `json:"expiration,omitempty"`
+		CanDeleteAtExpiration bool         `json:"canDeleteAtExpiration,omitempty"`
+		ContactBilling        string       `json:"contactBilling,omitempty"`
+		ContactTech           string       `json:"contactTech,omitempty"`
+		ContactAdmin          string       `json:"contactAdmin,omitempty"`
+	}
+
+	// ServiceRenew billing renew config
+	ServiceRenew struct {
+		ManualPayment      bool  `json:"manualPayment,omitempty"`
+		Period             int64 `json:"period,omitempty"`
+		Forced             bool  `json:"forced,omitempty"`
+		Automatic          bool  `json:"automatic,omitempty"`
+		DeleteAtExpiration bool  `json:"deleteAtExpiration,omitempty"`
+	}
+
+	// EditInfosRequest set service renew options
+	EditInfosRequest struct {
+		Service struct {
+			Renew ServiceRenew `json:"renew"`
+		} `json:"service"`
+	}
+
+	// NewTokenRequest for token creation
+	NewTokenRequest struct {
+		Description string
+		Labels      TokenLabels `json:"labels"`
+		Permission  string      `json:"permission"`
+	}
+
+	// TokenLabel labelset
+	TokenLabel struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}
+
+	// TokenLabels list of labelset
+	TokenLabels []TokenLabel
+
+	// EditTokenRequest token options update
+	EditTokenRequest struct {
+		Description string `json:"description"`
+	}
+)

--- a/metrics/service-helper.go
+++ b/metrics/service-helper.go
@@ -1,0 +1,36 @@
+package metrics
+
+import "github.com/ovh/go-ovh/ovh"
+
+// Tokens return all tokens linked to the Metrics service
+func (s *Service) Tokens(c *ovh.Client) (Tokens, error) {
+	tokenIDs, err := ListTokens(c, s.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	tokens := make(Tokens, len(tokenIDs))
+	for i, tokenID := range tokenIDs {
+		t, err := GetToken(c, s.Name, tokenID)
+		if err != nil {
+			return nil, err
+		}
+		tokens[i] = t
+	}
+	return tokens, nil
+}
+
+// Len implement sort.Sort()
+func (s Services) Len() int {
+	return len(s)
+}
+
+// Swap implement sort.Sort()
+func (s Services) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less implement sort.Sort()
+func (s Services) Less(i, j int) bool {
+	return s[i].Description < s[j].Description
+}


### PR DESCRIPTION
This is a tiny wrapper over ***/metric*** API.

Motivation:
Customers want a higher level API wrapper than a simple request builder (see #10).

This PR provide 2 way to use /metrics API

To get services
Ex1:
Get(ovh.Client) []string // Metrics service IDs list
Ex2:
NewClient(ovh.Client).Services()

The second approach give an easier way to use the API, beacause Services() method doesn't return a list of IDs but also fetch them and return a real list of Services