### PR TITLE
Add Context to requests

### DIFF
--- a/ovh/consumer_key_test.go
+++ b/ovh/consumer_key_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 // Common helpers are in ovh_test.go
@@ -19,7 +20,7 @@ func TestNewCkRequest(t *testing.T) {
 		"validationUrl":"https://validation.url",
 		"ConsumerKey":"`+MockConsumerKey+`",
 		"state":"pendingValidation"
-	}`, &InputRequestBody)
+	}`, &InputRequestBody, time.Duration(0))
 	client.ConsumerKey = ""
 	defer ts.Close()
 
@@ -54,7 +55,7 @@ func TestInvalidCkRequest(t *testing.T) {
 	// Init test
 	var InputRequest *http.Request
 	var InputRequestBody string
-	ts, client := initMockServer(&InputRequest, http.StatusForbidden, `{"message":"Invalid application key"}`, &InputRequestBody)
+	ts, client := initMockServer(&InputRequest, http.StatusForbidden, `{"message":"Invalid application key"}`, &InputRequestBody, time.Duration(0))
 	client.ConsumerKey = ""
 	defer ts.Close()
 
@@ -85,7 +86,7 @@ func TestAddRules(t *testing.T) {
 	// Init test
 	var InputRequest *http.Request
 	var InputRequestBody string
-	ts, client := initMockServer(&InputRequest, http.StatusForbidden, `{"message":"Invalid application key"}`, &InputRequestBody)
+	ts, client := initMockServer(&InputRequest, http.StatusForbidden, `{"message":"Invalid application key"}`, &InputRequestBody, time.Duration(0))
 	client.ConsumerKey = ""
 	defer ts.Close()
 

--- a/ovh/ovh.go
+++ b/ovh/ovh.go
@@ -3,6 +3,7 @@ package ovh
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha1"
 	"encoding/json"
 	"errors"
@@ -175,6 +176,46 @@ func (c *Client) DeleteUnAuth(url string, resType interface{}) error {
 	return c.CallAPI("DELETE", url, nil, resType, false)
 }
 
+// GetWithContext is a wrapper for the GET method
+func (c *Client) GetWithContext(ctx context.Context, url string, resType interface{}) error {
+	return c.CallAPIWithContext(ctx, "GET", url, nil, resType, true)
+}
+
+// GetUnAuthWithContext is a wrapper for the unauthenticated GET method
+func (c *Client) GetUnAuthWithContext(ctx context.Context, url string, resType interface{}) error {
+	return c.CallAPIWithContext(ctx, "GET", url, nil, resType, false)
+}
+
+// PostWithContext is a wrapper for the POST method
+func (c *Client) PostWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
+	return c.CallAPIWithContext(ctx, "POST", url, reqBody, resType, true)
+}
+
+// PostUnAuthWithContext is a wrapper for the unauthenticated POST method
+func (c *Client) PostUnAuthWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
+	return c.CallAPIWithContext(ctx, "POST", url, reqBody, resType, false)
+}
+
+// PutWithContext is a wrapper for the PUT method
+func (c *Client) PutWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
+	return c.CallAPIWithContext(ctx, "PUT", url, reqBody, resType, true)
+}
+
+// PutUnAuthWithContext is a wrapper for the unauthenticated PUT method
+func (c *Client) PutUnAuthWithContext(ctx context.Context, url string, reqBody, resType interface{}) error {
+	return c.CallAPIWithContext(ctx, "PUT", url, reqBody, resType, false)
+}
+
+// DeleteWithContext is a wrapper for the DELETE method
+func (c *Client) DeleteWithContext(ctx context.Context, url string, resType interface{}) error {
+	return c.CallAPIWithContext(ctx, "DELETE", url, nil, resType, true)
+}
+
+// DeleteUnAuthWithContext is a wrapper for the unauthenticated DELETE method
+func (c *Client) DeleteUnAuthWithContext(ctx context.Context, url string, resType interface{}) error {
+	return c.CallAPIWithContext(ctx, "DELETE", url, nil, resType, false)
+}
+
 // timeDelta returns the time  delta between the host and the remote API
 func (c *Client) getTimeDelta() (time.Duration, error) {
 
@@ -316,16 +357,40 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 // If everything went fine, unmarshall response into resType and return nil
 // otherwise, return the error
 func (c *Client) CallAPI(method, path string, reqBody, resType interface{}, needAuth bool) error {
+	return c.CallAPIWithContext(context.Background(), method, path, reqBody, resType, needAuth)
+}
+
+// CallAPIWithContext is the lowest level call helper. If needAuth is true,
+// inject authentication headers and sign the request.
+//
+// Request signature is a sha1 hash on following fields, joined by '+':
+// - applicationSecret (from Client instance)
+// - consumerKey (from Client instance)
+// - capitalized method (from arguments)
+// - full request url, including any query string argument
+// - full serialized request body
+// - server current time (takes time delta into account)
+//
+// Context is used by http.Client to handle context cancelation
+//
+// Call will automatically assemble the target url from the endpoint
+// configured in the client instance and the path argument. If the reqBody
+// argument is not nil, it will also serialize it as json and inject
+// the required Content-Type header.
+//
+// If everything went fine, unmarshall response into resType and return nil
+// otherwise, return the error
+func (c *Client) CallAPIWithContext(ctx context.Context, method, path string, reqBody, resType interface{}, needAuth bool) error {
 	req, err := c.NewRequest(method, path, reqBody, needAuth)
 	if err != nil {
 		return err
 	}
+	req = req.WithContext(ctx)
 	response, err := c.Do(req)
 	if err != nil {
 		return err
 	}
 	return c.UnmarshalResponse(response, resType)
-
 }
 
 // UnmarshalResponse checks the response and unmarshals it into the response


### PR DESCRIPTION
This pull-requests adds new wrapper functions to pass a context.Context, in order to cancel the underlying HTTP transport, usefull when used inside goroutine and we need to cancel a tree.

Requires #41 to be merged