### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,17 @@ jobs:
     - go: 1.14.x
     - go: 1.x
     - go: tip
+# Adding ppc64le jobs
+    - go: 1.12.x
+      arch: ppc64le
+    - go: 1.13.x
+      arch: ppc64le
+    - go: 1.14.x
+      arch: ppc64le
+    - go: 1.x
+      arch: ppc64le
+    - go: tip
+      arch: ppc64le
   allow_failures:
     - go: tip
 
@@ -36,8 +47,7 @@ script:
   - go test -covermode=count -coverprofile=profile.cov ./...
 
   # Test buildable on most common platforms, beyond Linux
-  - GOOS=darwin go build ./...
-  - GOOS=windows go build ./...
+  - if [[ "$TRAVIS_CPU_ARCH" != "ppc64le" ]]; then  GOOS=darwin go build ./... ;  GOOS=windows go build ./... ; fi
 
   # Best effort: notify coveralls. It's too unstable, ignore errors.
-  - $HOME/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci || exit 0
+  - if [[ "$TRAVIS_CPU_ARCH" != "ppc64le" ]]; then $HOME/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci || exit 0 ; fi


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://www.travis-ci.com/github/kishorkunal-raj/go-ovh/builds/207196209

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj