### PR TITLE
accept-encoding gzip

### DIFF
--- a/ovh/ovh.go
+++ b/ovh/ovh.go
@@ -288,6 +288,7 @@ func (c *Client) NewRequest(method, path string, reqBody interface{}, needAuth b
 	}
 	req.Header.Add("X-Ovh-Application", c.AppKey)
 	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept-Encoding", "gzip, deflate, br")
 
 	// Inject signature. Some methods do not need authentication, especially /time,
 	// /auth and some /order methods are actually broken if authenticated.


### PR DESCRIPTION
cf #53 
Adding Accept-Encoding header seems to work, I could do a POST on `/1.0/cloud/project/***/kube/***/nodepool` to create and attach a nodepool to a cluster programmatically.
This particular endpoint seems finicky as hell on the format it accepts, but at least there is no more problem with gzip compression. 

Untested on other endpoints.