### PR TITLE
Fix API Error when error body is empty

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ovh/go-ovh
+module github.com/codetruelle/go-ovh
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/codetruelle/go-ovh
+module github.com/ovh/go-ovh
 
 go 1.18
 

--- a/ovh/ovh.go
+++ b/ovh/ovh.go
@@ -397,21 +397,33 @@ func (c *Client) CallAPIWithContext(ctx context.Context, method, path string, re
 // UnmarshalResponse checks the response and unmarshals it into the response
 // type if needed Helper function, called from CallAPI
 func (c *Client) UnmarshalResponse(response *http.Response, resType interface{}) error {
-	// Read all the response body
-	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return err
-	}
 
 	// < 200 && >= 300 : API error
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+
+		// Read all the response body
+		defer response.Body.Close()
+		errBody, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			// If we cannot read the body, send back the status code as an error
+			apiError := &APIError{Code: response.StatusCode}
+			return apiError
+		}
+
+		// if we have a body for the error - create API error from the body
 		apiError := &APIError{Code: response.StatusCode}
-		if err = json.Unmarshal(body, apiError); err != nil {
-			apiError.Message = string(body)
+		if err = json.Unmarshal(errBody, apiError); err != nil {
+			apiError.Message = string(errBody)
 		}
 		apiError.QueryID = response.Header.Get("X-Ovh-QueryID")
 
+		return apiError
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		// If we cannot read the body, send back the status code as an error
+		apiError := &APIError{Code: response.StatusCode}
 		return apiError
 	}
 
@@ -424,3 +436,4 @@ func (c *Client) UnmarshalResponse(response *http.Response, resType interface{})
 	d.UseNumber()
 	return d.Decode(&resType)
 }
+

--- a/ovh/ovh_test.go
+++ b/ovh/ovh_test.go
@@ -325,11 +325,12 @@ func TestGetResponse(t *testing.T) {
 	}, "Can parse a API error")
 	td.Cmp(t, apiInt, 0)
 
-	// Error: body read error
+	// Error: Cannot read the error body
 	err = client.UnmarshalResponse(&http.Response{
-		Body: ErrorReadCloser{},
+		StatusCode: 400,
+		Body:       ErrorReadCloser{},
 	}, nil)
-	td.CmpString(t, err, "ErrorReader")
+	td.Cmp(t, err, &APIError{Code: 400})
 
 	// Error: HTTP Error + broken json
 	err = client.UnmarshalResponse(&http.Response{


### PR DESCRIPTION
When an API call is returning a bad status code (!=200) and no body, the client return the body read error EOF instead of the error code. It's more difficult to debug and understand what happened.
A call to POST /cloud/project/*/instance with a bad or empty image id will return EOF.
With this patch, it return the 404 error saying an object is not found.
It's not perfect as the API should return the exact error, but more useful than EOF.