### PR TITLE
feat: Add ability to use go-ovh in a WebAssembly binary

### DIFF
--- a/ovh/configuration_test.go
+++ b/ovh/configuration_test.go
@@ -143,7 +143,7 @@ func TestMissingParam(t *testing.T) {
 
 	client.endpoint = ""
 	err := client.loadConfig("")
-	td.CmpString(t, err, `unknown endpoint '', consider checking 'Endpoints' list or using an URL`)
+	td.CmpNoError(t, err)
 
 	client.AppKey = ""
 	err = client.loadConfig("ovh-eu")

--- a/ovh/ovh_test.go
+++ b/ovh/ovh_test.go
@@ -401,10 +401,10 @@ func TestGetResponseUnmarshalNumber(t *testing.T) {
 func TestConstructors(t *testing.T) {
 	assert, require := td.AssertRequire(t)
 
-	// Error: missing Endpoint
+	// Missing Endpoint, defaulting to ovh-eu
 	client, err := NewClient("", MockApplicationKey, MockApplicationSecret, MockConsumerKey)
-	assert.Nil(client)
-	assert.String(err, `unknown endpoint '', consider checking 'Endpoints' list or using an URL`)
+	assert.NotNil(client)
+	assert.CmpNoError(err)
 
 	// Error: missing ApplicationKey
 	client, err = NewClient("ovh-eu", "", MockApplicationSecret, MockConsumerKey)
@@ -449,10 +449,10 @@ func TestConstructors(t *testing.T) {
 func TestConstructorsOAuth2(t *testing.T) {
 	assert, require := td.AssertRequire(t)
 
-	// Error: missing Endpoint
+	// Missing Endpoint: defaulting to ovh-eu
 	client, err := NewOAuth2Client("", "aaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb")
-	assert.Nil(client)
-	assert.String(err, `unknown endpoint '', consider checking 'Endpoints' list or using an URL`)
+	assert.NotNil(client)
+	assert.CmpNoError(err)
 
 	// Error: missing Client ID
 	client, err = NewOAuth2Client("ovh-eu", "", "MockApplicationSecret")
@@ -489,10 +489,10 @@ func TestConstructorsOAuth2(t *testing.T) {
 func TestConstructorsAccessToken(t *testing.T) {
 	assert, require := td.AssertRequire(t)
 
-	// Error: missing Endpoint
+	// Missing Endpoint: defaulting to ovh-eu
 	client, err := NewAccessTokenClient("", "aaaaaaaa")
-	assert.Nil(client)
-	assert.String(err, `unknown endpoint '', consider checking 'Endpoints' list or using an URL`)
+	assert.NotNil(client)
+	assert.CmpNoError(err)
 
 	// Next: success cases
 	expected := td.Struct(&Client{


### PR DESCRIPTION
Avoid trying to load ini configuration files  when building with `GOARCH=wasm GOOS=js` as it is not possible.