### PR TITLE
feat: migrate API and OAuth2 URLs to new OVHcloud domains

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2015-2025, OVH SAS
+Copyright (c) 2015-2026, OVH SAS
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ go vet ./...
 - **Community support**: api-subscribe@ml.ovh.net
 - **Console**: https://api.ca.ovhcloud.com/console
 - **Create application credentials**: https://auth.ca.ovhcloud.com/api/createApp
-- **Create script credentials** (all keys at once): https://auth.ca.ovhcloud.com/api/createToken/
+- **Create script credentials** (all keys at once): https://auth.ca.ovhcloud.com/api/createToken
 
 ### So you Start Europe
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ type PartialMe struct {
 }
 
 // Instantiate an OVH client and get the firstname of the currently logged-in user.
-// Visit https://api.eu.ovhcloud.com/createToken/index.cgi?GET=/me to get your credentials.
+// Visit https://auth.eu.ovhcloud.com/api/createToken/index.cgi?GET=/me to get your credentials.
 func main() {
 	var me PartialMe
 
@@ -187,7 +187,7 @@ credentials at once. See below.
 
 ##### Use the API on behalf of a user
 
-Visit [https://api.eu.ovhcloud.com/createApp](https://api.eu.ovhcloud.com/createApp) and create your app
+Visit [https://auth.eu.ovhcloud.com/api/createApp](https://auth.eu.ovhcloud.com/api/createApp) and create your app
 You'll get an application key and an application secret. To use the API you'll need a consumer key.
 
 The consumer key has two types of restriction:
@@ -252,7 +252,7 @@ func main() {
 Alternatively, you may generate all creadentials at once, including the consumer key. You will
 typically want to do this when writing automation scripts for a single projects.
 
-If this case, you may want to directly go to https://api.eu.ovhcloud.com/createToken/ to generate
+If this case, you may want to directly go to https://auth.eu.ovhcloud.com/api/createToken/ to generate
 the 3 tokens at once. Make sure to save them in one of the 'ovh.conf' configuration file.
 Please see the [configuration section](#configuration).
 
@@ -545,8 +545,8 @@ go vet ./...
 - **Documentation**: https://api.eu.ovhcloud.com/
 - **Community support**: api-subscribe@ml.ovh.net
 - **Console**: https://api.eu.ovhcloud.com/console
-- **Create application credentials**: https://api.eu.ovhcloud.com/createApp/
-- **Create script credentials** (all keys at once): https://api.eu.ovhcloud.com/createToken/
+- **Create application credentials**: https://auth.eu.ovhcloud.com/api/createApp/
+- **Create script credentials** (all keys at once): https://auth.eu.ovhcloud.com/api/createToken/
 
 ### OVHcloud US
 
@@ -560,8 +560,8 @@ go vet ./...
 - **Documentation**: https://api.ca.ovhcloud.com/
 - **Community support**: api-subscribe@ml.ovh.net
 - **Console**: https://api.ca.ovhcloud.com/console
-- **Create application credentials**: https://api.ca.ovhcloud.com/createApp/
-- **Create script credentials** (all keys at once): https://api.ca.ovhcloud.com/createToken/
+- **Create application credentials**: https://auth.ca.ovhcloud.com/api/createApp/
+- **Create script credentials** (all keys at once): https://auth.ca.ovhcloud.com/api/createToken/
 
 ### So you Start Europe
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ import (
 )
 
 // PartialMe holds the first name of the currently logged-in user.
-// Visit https://api.ovh.com/console/#/me#GET for the full definition
+// Visit https://api.eu.ovhcloud.com/console/#/me#GET for the full definition
 type PartialMe struct {
 	Firstname string `json:"firstname"`
 }
 
 // Instantiate an OVH client and get the firstname of the currently logged-in user.
-// Visit https://api.ovh.com/createToken/index.cgi?GET=/me to get your credentials.
+// Visit https://api.eu.ovhcloud.com/createToken/index.cgi?GET=/me to get your credentials.
 func main() {
 	var me PartialMe
 
@@ -187,7 +187,7 @@ credentials at once. See below.
 
 ##### Use the API on behalf of a user
 
-Visit [https://eu.api.ovh.com/createApp](https://eu.api.ovh.com/createApp) and create your app
+Visit [https://api.eu.ovhcloud.com/createApp](https://api.eu.ovhcloud.com/createApp) and create your app
 You'll get an application key and an application secret. To use the API you'll need a consumer key.
 
 The consumer key has two types of restriction:
@@ -252,7 +252,7 @@ func main() {
 Alternatively, you may generate all creadentials at once, including the consumer key. You will
 typically want to do this when writing automation scripts for a single projects.
 
-If this case, you may want to directly go to https://eu.api.ovh.com/createToken/ to generate
+If this case, you may want to directly go to https://api.eu.ovhcloud.com/createToken/ to generate
 the 3 tokens at once. Make sure to save them in one of the 'ovh.conf' configuration file.
 Please see the [configuration section](#configuration).
 
@@ -355,22 +355,22 @@ func main() {
 When using OVHcloud APIs (not So you Start or Kimsufi ones), you are given the
 opportunity to aim for two API versions. For the European API, for example:
 
-- the v1 is reachable through https://eu.api.ovh.com/v1
-- the v2 is reachable through https://eu.api.ovh.com/v2
-- the legacy URL is https://eu.api.ovh.com/1.0
+- the v1 is reachable through https://api.eu.ovhcloud.com/v1
+- the v2 is reachable through https://api.eu.ovhcloud.com/v2
+- the legacy URL is https://api.eu.ovhcloud.com/1.0
 
 Calling `client.Get`, you can target the API version you want:
 
 ```go
 client, _ := ovh.NewEndpointClient("ovh-eu")
 
-// Call to https://eu.api.ovh.com/v1/xdsl/xdsl-yourservice
+// Call to https://api.eu.ovhcloud.com/v1/xdsl/xdsl-yourservice
 client.Get("/v1/xdsl/xdsl-yourservice", nil)
 
-// Call to https://eu.api.ovh.com/v2/xdsl/xdsl-yourservice
+// Call to https://api.eu.ovhcloud.com/v2/xdsl/xdsl-yourservice
 client.Get("/v2/xdsl/xdsl-yourservice", nil)
 
-// Legacy call to https://eu.api.ovh.com/1.0/xdsl/xdsl-yourservice
+// Legacy call to https://api.eu.ovhcloud.com/1.0/xdsl/xdsl-yourservice
 client.Get("/xdsl/xdsl-yourservice", nil)
 ```
 
@@ -542,11 +542,11 @@ go vet ./...
 
 ### OVHcloud Europe
 
-- **Documentation**: https://eu.api.ovh.com/
+- **Documentation**: https://api.eu.ovhcloud.com/
 - **Community support**: api-subscribe@ml.ovh.net
-- **Console**: https://eu.api.ovh.com/console
-- **Create application credentials**: https://eu.api.ovh.com/createApp/
-- **Create script credentials** (all keys at once): https://eu.api.ovh.com/createToken/
+- **Console**: https://api.eu.ovhcloud.com/console
+- **Create application credentials**: https://api.eu.ovhcloud.com/createApp/
+- **Create script credentials** (all keys at once): https://api.eu.ovhcloud.com/createToken/
 
 ### OVHcloud US
 
@@ -557,11 +557,11 @@ go vet ./...
 
 ### OVHcloud Canada
 
-- **Documentation**: https://ca.api.ovh.com/
+- **Documentation**: https://api.ca.ovhcloud.com/
 - **Community support**: api-subscribe@ml.ovh.net
-- **Console**: https://ca.api.ovh.com/console
-- **Create application credentials**: https://ca.api.ovh.com/createApp/
-- **Create script credentials** (all keys at once): https://ca.api.ovh.com/createToken/
+- **Console**: https://api.ca.ovhcloud.com/console
+- **Create application credentials**: https://api.ca.ovhcloud.com/createApp/
+- **Create script credentials** (all keys at once): https://api.ca.ovhcloud.com/createToken/
 
 ### So you Start Europe
 

--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ go vet ./...
 - **Documentation**: https://api.ca.ovhcloud.com/
 - **Community support**: api-subscribe@ml.ovh.net
 - **Console**: https://api.ca.ovhcloud.com/console
-- **Create application credentials**: https://auth.ca.ovhcloud.com/api/createApp/
+- **Create application credentials**: https://auth.ca.ovhcloud.com/api/createApp
 - **Create script credentials** (all keys at once): https://auth.ca.ovhcloud.com/api/createToken/
 
 ### So you Start Europe

--- a/ovh/consumer_key_test.go
+++ b/ovh/consumer_key_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (ms *MockSuite) TestNewCkRequest(assert, require *td.T) {
-	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/1.0/auth/credential", func(req *http.Request) (*http.Response, error) {
+	httpmock.RegisterResponder("POST", "https://api.eu.ovhcloud.com/1.0/auth/credential", func(req *http.Request) (*http.Response, error) {
 		assert.Cmp(req.Header["Accept"], []string{"application/json"})
 		assert.Cmp(req.Header["X-Ovh-Application"], []string{MockApplicationKey})
 		assert.Cmp(req.Body, td.Smuggle(json.RawMessage{}, td.JSON(`{"accessRules":[{"method":"GET","path":"/me"},{"method":"GET","path":"/xdsl/*"}]}`)))
@@ -37,7 +37,7 @@ func (ms *MockSuite) TestNewCkRequest(assert, require *td.T) {
 }
 
 func (ms *MockSuite) TestInvalidCkRequest(assert, require *td.T) {
-	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/1.0/auth/credential",
+	httpmock.RegisterResponder("POST", "https://api.eu.ovhcloud.com/1.0/auth/credential",
 		httpmock.NewStringResponder(http.StatusForbidden, `{"message":"Invalid application key"}`))
 
 	ckRequest := ms.client.NewCkRequest()

--- a/ovh/ovh.go
+++ b/ovh/ovh.go
@@ -28,8 +28,8 @@ const DefaultTimeout = 180 * time.Second
 
 // Endpoints
 const (
-	OvhEU        = "https://eu.api.ovh.com/1.0"
-	OvhCA        = "https://ca.api.ovh.com/1.0"
+	OvhEU        = "https://api.eu.ovhcloud.com/1.0"
+	OvhCA        = "https://api.ca.ovhcloud.com/1.0"
 	OvhUS        = "https://api.us.ovhcloud.com/1.0"
 	KimsufiEU    = "https://eu.api.kimsufi.com/1.0"
 	KimsufiCA    = "https://ca.api.kimsufi.com/1.0"
@@ -53,8 +53,8 @@ var (
 	ErrAPIDown = errors.New("go-ovh: the OVH API is not reachable: failed to get /auth/time response")
 
 	tokensURLs = map[string]string{
-		OvhEU: "https://www.ovh.com/auth/oauth2/token",
-		OvhCA: "https://ca.ovh.com/auth/oauth2/token",
+		OvhEU: "https://auth.eu.ovhcloud.com/oauth2/token",
+		OvhCA: "https://auth.ca.ovhcloud.com/oauth2/token",
 		OvhUS: "https://us.ovhcloud.com/auth/oauth2/token",
 	}
 )
@@ -65,7 +65,7 @@ type Client struct {
 	AccessToken string
 
 	// Self generated tokens. Create one by visiting
-	// https://eu.api.ovh.com/createApp/
+	// https://api.eu.ovhcloud.com/createApp/
 	// AppKey holds the Application key
 	AppKey string
 

--- a/ovh/ovh.go
+++ b/ovh/ovh.go
@@ -65,7 +65,7 @@ type Client struct {
 	AccessToken string
 
 	// Self generated tokens. Create one by visiting
-	// https://api.eu.ovhcloud.com/createApp/
+	// https://auth.eu.ovhcloud.com/api/createApp/
 	// AppKey holds the Application key
 	AppKey string
 

--- a/ovh/ovh_test.go
+++ b/ovh/ovh_test.go
@@ -87,36 +87,36 @@ func TestMockSuite(t *testing.T) {
 }
 
 func (ms *MockSuite) TestPing(assert *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/auth/time",
+	httpmock.RegisterResponder("GET", "https://api.eu.ovhcloud.com/1.0/auth/time",
 		httpmock.NewStringResponder(200, "0"))
 
 	assert.CmpNoError(ms.client.Ping())
-	assert.Cmp(httpmock.GetCallCountInfo()["GET https://eu.api.ovh.com/1.0/auth/time"], 1)
+	assert.Cmp(httpmock.GetCallCountInfo()["GET https://api.eu.ovhcloud.com/1.0/auth/time"], 1)
 }
 
 func (ms *MockSuite) TestTime(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/auth/time",
+	httpmock.RegisterResponder("GET", "https://api.eu.ovhcloud.com/1.0/auth/time",
 		httpmock.NewStringResponder(200, strconv.Itoa(MockTime)))
 
 	serverTime, err := ms.client.Time()
 	require.CmpNoError(err)
 	assert.CmpLax(serverTime.Unix(), MockTime)
-	assert.Cmp(httpmock.GetCallCountInfo()["GET https://eu.api.ovh.com/1.0/auth/time"], 1)
+	assert.Cmp(httpmock.GetCallCountInfo()["GET https://api.eu.ovhcloud.com/1.0/auth/time"], 1)
 }
 
 func (ms *MockSuite) TestGetTimeDelta(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/auth/time",
+	httpmock.RegisterResponder("GET", "https://api.eu.ovhcloud.com/1.0/auth/time",
 		httpmock.NewStringResponder(200, strconv.FormatInt(time.Now().Unix()-10, 10)))
 
 	delta, err := ms.client.TimeDelta()
 	require.CmpNoError(err)
 	assert.Between(delta.Seconds(), 9.0, 11.0, td.BoundsInIn)
-	assert.Cmp(httpmock.GetCallCountInfo()["GET https://eu.api.ovh.com/1.0/auth/time"], 1)
+	assert.Cmp(httpmock.GetCallCountInfo()["GET https://api.eu.ovhcloud.com/1.0/auth/time"], 1)
 }
 
 func (ms *MockSuite) TestError500HTML(assert, require *td.T) {
 	errHTML := `<html><body><p>test</p></body></html>`
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/test",
+	httpmock.RegisterResponder("GET", "https://api.eu.ovhcloud.com/1.0/test",
 		httpmock.NewStringResponder(http.StatusServiceUnavailable, errHTML))
 
 	err := ms.client.CallAPI("GET", "/test", nil, nil, false)
@@ -158,34 +158,34 @@ func (ms *MockSuite) TestAllAPIMethods(assert, require *td.T) {
 		}
 	}
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/auth/time",
+	httpmock.RegisterResponder("GET", "https://api.eu.ovhcloud.com/1.0/auth/time",
 		httpmock.NewStringResponder(200, strconv.Itoa(MockTime)))
 
 	mockSignatures := map[string]struct{ authSig, timeoutSig string }{
-		"GET":    {authSig: "$1$e9556054b6309771395efa467c22e627407461ad", timeoutSig: "$1$1f0958be70f095ddaba525778a9ac1dcffac89f3"},
-		"POST":   {authSig: "$1$ec2fb5c7a81f64723c77d2e5b609ae6f58a84fc1", timeoutSig: "$1$b592effcb3bc2d37860eceb06a1b17670fbe49c6"},
-		"PUT":    {authSig: "$1$8a75a9e7c8e7296c9dbeda6a2a735eb6bd58ec4b", timeoutSig: "$1$6b27c2a693a0eb4980217046b2fe10d74ba796f0"},
-		"DELETE": {authSig: "$1$a1eecd00b3b02b6cf5708b84b9ff42059a950d85", timeoutSig: "$1$bd59b15361548c388058009e00c508081e991e8b"},
+		"GET":    {authSig: "$1$52992e595b398f6aba591ee5925b379081614ced", timeoutSig: "$1$fbf2332d802de7f075e1b5bc52bd2fbed6790224"},
+		"POST":   {authSig: "$1$ea0e0d82447373a3ddf5947065f1d519ca0bcaf2", timeoutSig: "$1$4e23630584237237f4667e19e8ebe45c70a0b8b8"},
+		"PUT":    {authSig: "$1$0fdc3ed192ffbf3d1be414dbb733bbb7729500ee", timeoutSig: "$1$8768dfec08fa37f7af6a913ac0f2c6b63a0e377f"},
+		"DELETE": {authSig: "$1$f685c165fa9da88b294b5fd2504588588105f994", timeoutSig: "$1$7b00b6432e4b2e168a3147240a074617c1ae483c"},
 	}
 	buildMock := func(assert *td.T, method string) {
 		method = strings.ToUpper(method)
-		httpmock.RegisterResponder(method, "https://eu.api.ovh.com/1.0/auth", func(req *http.Request) (*http.Response, error) {
+		httpmock.RegisterResponder(method, "https://api.eu.ovhcloud.com/1.0/auth", func(req *http.Request) (*http.Response, error) {
 			checkAuthHeaders(assert, req, mockSignatures[method].authSig)
 			checkBody(assert, req)
 			return httpmock.NewStringResponse(200, payloadAuth), nil
 		})
-		httpmock.RegisterResponder(method, "https://eu.api.ovh.com/1.0/unauth", func(req *http.Request) (*http.Response, error) {
+		httpmock.RegisterResponder(method, "https://api.eu.ovhcloud.com/1.0/unauth", func(req *http.Request) (*http.Response, error) {
 			checkAuthHeaders(assert, req, "")
 			checkBody(assert, req)
 			return httpmock.NewStringResponse(200, payloadUnAuth), nil
 		})
-		httpmock.RegisterResponder(method, "https://eu.api.ovh.com/1.0/authTO", func(req *http.Request) (*http.Response, error) {
+		httpmock.RegisterResponder(method, "https://api.eu.ovhcloud.com/1.0/authTO", func(req *http.Request) (*http.Response, error) {
 			checkAuthHeaders(assert, req, mockSignatures[method].timeoutSig)
 			checkBody(assert, req)
 			time.Sleep(200 * time.Millisecond)
 			return httpmock.NewStringResponse(200, `{"call":"authTO"}`), nil
 		})
-		httpmock.RegisterResponder(method, "https://eu.api.ovh.com/1.0/unauthTO", func(req *http.Request) (*http.Response, error) {
+		httpmock.RegisterResponder(method, "https://api.eu.ovhcloud.com/1.0/unauthTO", func(req *http.Request) (*http.Response, error) {
 			checkAuthHeaders(assert, req, "")
 			checkBody(assert, req)
 			time.Sleep(200 * time.Millisecond)
@@ -231,7 +231,7 @@ func (ms *MockSuite) TestAllAPIMethods(assert, require *td.T) {
 			err = test.callWithContext(ctx, "/authTO", &res)
 			assert.Empty(res, "Empty result after timeout for method %s with auth", test.method)
 			assert.String(err,
-				test.method+` "https://eu.api.ovh.com/1.0/authTO": context deadline exceeded`,
+				test.method+` "https://api.eu.ovhcloud.com/1.0/authTO": context deadline exceeded`,
 				"Timeout messsage for method %s with auth", test.method,
 			)
 
@@ -241,7 +241,7 @@ func (ms *MockSuite) TestAllAPIMethods(assert, require *td.T) {
 			err = test.callUnAuthWithContext(ctx, "/unauthTO", &res)
 			assert.Empty(res, "Empty result after timeout for method %s without auth", test.method)
 			assert.String(err,
-				test.method+` "https://eu.api.ovh.com/1.0/unauthTO": context deadline exceeded`,
+				test.method+` "https://api.eu.ovhcloud.com/1.0/unauthTO": context deadline exceeded`,
 				"Timeout messsage for method %s without auth", test.method,
 			)
 		})
@@ -284,7 +284,7 @@ func (ms *MockSuite) TestAllAPIMethods(assert, require *td.T) {
 			assert.Cleanup(cancel)
 			err = test.callWithContext(ctx, "/authTO", body, &res)
 			assert.String(err,
-				test.method+` "https://eu.api.ovh.com/1.0/authTO": context deadline exceeded`,
+				test.method+` "https://api.eu.ovhcloud.com/1.0/authTO": context deadline exceeded`,
 				"Timeout messsage for method %s with auth", test.method,
 			)
 			assert.Empty(res, "Empty result after timeout for method %s with auth", test.method)
@@ -294,7 +294,7 @@ func (ms *MockSuite) TestAllAPIMethods(assert, require *td.T) {
 			assert.Cleanup(cancel)
 			err = test.callUnAuthWithContext(ctx, "/unauthTO", body, &res)
 			assert.String(err,
-				test.method+` "https://eu.api.ovh.com/1.0/unauthTO": context deadline exceeded`,
+				test.method+` "https://api.eu.ovhcloud.com/1.0/unauthTO": context deadline exceeded`,
 				"Timeout messsage for method %s without auth", test.method,
 			)
 			assert.Empty(res, "Empty result after timeout for method %s without auth", test.method)
@@ -421,7 +421,7 @@ func TestConstructors(t *testing.T) {
 		AppKey:      MockApplicationKey,
 		AppSecret:   MockApplicationSecret,
 		ConsumerKey: MockConsumerKey,
-		endpoint:    "https://eu.api.ovh.com/1.0",
+		endpoint:    "https://api.eu.ovhcloud.com/1.0",
 	})
 
 	// Nominal: full constructor
@@ -468,7 +468,7 @@ func TestConstructorsOAuth2(t *testing.T) {
 	expected := td.Struct(&Client{
 		ClientID:     "aaaaaaaa",
 		ClientSecret: "bbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-		endpoint:     "https://eu.api.ovh.com/1.0",
+		endpoint:     "https://api.eu.ovhcloud.com/1.0",
 	})
 
 	// Nominal: full constructor
@@ -497,7 +497,7 @@ func TestConstructorsAccessToken(t *testing.T) {
 	// Next: success cases
 	expected := td.Struct(&Client{
 		AccessToken: "aaaaaaaa",
-		endpoint:    "https://eu.api.ovh.com/1.0",
+		endpoint:    "https://api.eu.ovhcloud.com/1.0",
 	})
 
 	// Nominal: full constructor
@@ -508,16 +508,16 @@ func TestConstructorsAccessToken(t *testing.T) {
 
 func (ms *MockSuite) TestVersionInURL(assert, require *td.T) {
 	// Signature checking mocks
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/call", func(req *http.Request) (*http.Response, error) {
-		assert.Cmp(req.Header["X-Ovh-Signature"], []string{"$1$7f2db49253edfc41891023fcd1a54cf61db05fbb"}, "Right X-Ovh-Signature for /1.0 auth call")
+	httpmock.RegisterResponder("GET", "https://api.eu.ovhcloud.com/1.0/call", func(req *http.Request) (*http.Response, error) {
+		assert.Cmp(req.Header["X-Ovh-Signature"], []string{"$1$4f3e3e887cc2ce88a0078801d849b8e2c482e997"}, "Right X-Ovh-Signature for /1.0 auth call")
 		return httpmock.NewStringResponse(200, "{}"), nil
 	})
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/call", func(req *http.Request) (*http.Response, error) {
-		assert.Cmp(req.Header["X-Ovh-Signature"], []string{"$1$e6e7906d385eb28adcbfbe6b66c1528a42d741ad"}, "Right X-Ovh-Signature for /v1 auth call")
+	httpmock.RegisterResponder("GET", "https://api.eu.ovhcloud.com/v1/call", func(req *http.Request) (*http.Response, error) {
+		assert.Cmp(req.Header["X-Ovh-Signature"], []string{"$1$35654374999e2e09ef148973c54279a68f15e0a2"}, "Right X-Ovh-Signature for /v1 auth call")
 		return httpmock.NewStringResponse(200, "{}"), nil
 	})
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v2/call", func(req *http.Request) (*http.Response, error) {
-		assert.Cmp(req.Header["X-Ovh-Signature"], []string{"$1$bb63b132a6f84ad5433d0c534d48d3f7c3804285"}, "Right X-Ovh-Signature for /v2 auth call")
+	httpmock.RegisterResponder("GET", "https://api.eu.ovhcloud.com/v2/call", func(req *http.Request) (*http.Response, error) {
+		assert.Cmp(req.Header["X-Ovh-Signature"], []string{"$1$85b6382fc0cca761b193007763c908bc68ca4a50"}, "Right X-Ovh-Signature for /v2 auth call")
 		return httpmock.NewStringResponse(200, "{}"), nil
 	})
 
@@ -528,20 +528,20 @@ func (ms *MockSuite) TestVersionInURL(assert, require *td.T) {
 	}
 	assert.Cleanup(func() { getLocalTime = previous })
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/auth/time",
+	httpmock.RegisterResponder("GET", "https://api.eu.ovhcloud.com/1.0/auth/time",
 		httpmock.NewStringResponder(200, strconv.Itoa(MockTime)))
 
 	assertCallCount := func(assert *td.T, ccNoVersion, ccV1, ccV2 int) {
 		assert.Helper()
 		assert.Cmp(httpmock.GetCallCountInfo(), map[string]int{
-			"GET https://eu.api.ovh.com/1.0/auth/time": 1,
-			"GET https://eu.api.ovh.com/1.0/call":      ccNoVersion,
-			"GET https://eu.api.ovh.com/v1/call":       ccV1,
-			"GET https://eu.api.ovh.com/v2/call":       ccV2,
+			"GET https://api.eu.ovhcloud.com/1.0/auth/time": 1,
+			"GET https://api.eu.ovhcloud.com/1.0/call":      ccNoVersion,
+			"GET https://api.eu.ovhcloud.com/v1/call":       ccV1,
+			"GET https://api.eu.ovhcloud.com/v2/call":       ccV2,
 		})
 	}
 
-	require.Cmp(ms.client.endpoint, "https://eu.api.ovh.com/1.0")
+	require.Cmp(ms.client.endpoint, "https://api.eu.ovhcloud.com/1.0")
 
 	require.CmpNoError(ms.client.Get("/call", nil))
 	assertCallCount(assert, 1, 0, 0)
@@ -559,7 +559,7 @@ func TestOAuth2_503(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	errHTML := `<html><body><p>test</p></body></html>`
-	httpmock.RegisterResponder("POST", "https://www.ovh.com/auth/oauth2/token",
+	httpmock.RegisterResponder("POST", "https://auth.eu.ovhcloud.com/oauth2/token",
 		httpmock.NewStringResponder(http.StatusServiceUnavailable, errHTML))
 
 	// Nominal: full constructor
@@ -576,7 +576,7 @@ func TestOAuth2_BadJSON(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	errHTML := `<html><body><p>test</p></body></html>`
-	httpmock.RegisterResponder("POST", "https://www.ovh.com/auth/oauth2/token",
+	httpmock.RegisterResponder("POST", "https://auth.eu.ovhcloud.com/oauth2/token",
 		httpmock.NewStringResponder(http.StatusOK, errHTML))
 
 	// Nominal: full constructor
@@ -593,7 +593,7 @@ func TestOAuth2_UnknownClient(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	output := `{"error":"invalid_client", "error_description":"ovhcloud oauth2 client does not exists"}`
-	httpmock.RegisterResponder("POST", "https://www.ovh.com/auth/oauth2/token",
+	httpmock.RegisterResponder("POST", "https://auth.eu.ovhcloud.com/oauth2/token",
 		httpmock.NewStringResponder(http.StatusBadRequest, output))
 
 	// Nominal: full constructor
@@ -612,9 +612,9 @@ func TestOAuth2_OK(t *testing.T) {
 	// expires_in set to 11 seconds. Will test that token are well renewed.
 	// golang.org/x/oauth2 has internal 10 seconds period that it will use to renew the token before actual expiration
 	output := `{"access_token":"cccccccccccccccc", "token_type":"Bearer", "expires_in":11,"scope":"all"}`
-	httpmock.RegisterResponder("POST", "https://www.ovh.com/auth/oauth2/token",
+	httpmock.RegisterResponder("POST", "https://auth.eu.ovhcloud.com/oauth2/token",
 		httpmock.NewStringResponder(http.StatusOK, output))
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/auth/time",
+	httpmock.RegisterResponder("GET", "https://api.eu.ovhcloud.com/v1/auth/time",
 		func(req *http.Request) (*http.Response, error) {
 			assert.Cmp(req.Header.Get("Authorization"), "Bearer cccccccccccccccc")
 			resp, err := httpmock.NewJsonResponse(http.StatusOK, map[string]string{
@@ -636,8 +636,8 @@ func TestOAuth2_OK(t *testing.T) {
 	})
 
 	assert.Cmp(httpmock.GetCallCountInfo(), map[string]int{
-		"POST https://www.ovh.com/auth/oauth2/token": 1,
-		"GET https://eu.api.ovh.com/v1/auth/time":    1,
+		"POST https://auth.eu.ovhcloud.com/oauth2/token": 1,
+		"GET https://api.eu.ovhcloud.com/v1/auth/time":    1,
 	}, "no token at this time, retrieving the token")
 
 	httpmock.ZeroCallCounters()
@@ -645,8 +645,8 @@ func TestOAuth2_OK(t *testing.T) {
 	err = client.Get("/v1/auth/time", &out)
 	require.CmpNoError(err)
 	assert.Cmp(httpmock.GetCallCountInfo(), map[string]int{
-		"GET https://eu.api.ovh.com/v1/auth/time":    1,
-		"POST https://www.ovh.com/auth/oauth2/token": 0,
+		"GET https://api.eu.ovhcloud.com/v1/auth/time":    1,
+		"POST https://auth.eu.ovhcloud.com/oauth2/token": 0,
 	}, "token is still valid, no call to retrieve new token")
 
 	// waiting 3 seconds, to get below the 10 seconds period
@@ -657,8 +657,8 @@ func TestOAuth2_OK(t *testing.T) {
 	err = client.Get("/v1/auth/time", &out)
 	require.CmpNoError(err)
 	assert.Cmp(httpmock.GetCallCountInfo(), map[string]int{
-		"GET https://eu.api.ovh.com/v1/auth/time":    1,
-		"POST https://www.ovh.com/auth/oauth2/token": 1,
+		"GET https://api.eu.ovhcloud.com/v1/auth/time":    1,
+		"POST https://auth.eu.ovhcloud.com/oauth2/token": 1,
 	}, "token is considered as expired, renewing token")
 }
 


### PR DESCRIPTION
   - Replace https://api.ovh.com with https://api.eu.ovhcloud.com
   - Replace https://eu.api.ovh.com with https://api.eu.ovhcloud.com
   - Replace https://ca.api.ovh.com with https://api.ca.ovhcloud.com
   - Replace https://www.ovh.com/auth/oauth2/token with https://auth.eu.ovhcloud.com/oauth2/token
   - Replace https://ca.ovh.com/auth/oauth2/token with https://auth.ca.ovhcloud.com/oauth2/token
   - Update hardcoded SHA1 signatures in tests accordingly
   - Update documentation in README.md